### PR TITLE
Updates dependencies and bumps package; eliminates most warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-publish",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Poor man's semantic release utility. Let the CI do the `npm publish` step after the build passes",
   "main": "index.js",
   "bin": {
@@ -38,16 +38,16 @@
   },
   "homepage": "https://github.com/bahmutov/ci-publish#readme",
   "devDependencies": {
-    "ban-sensitive-files": "1.8.3",
+    "ban-sensitive-files": "1.9.2",
     "next-ver": "1.8.0",
-    "pre-git": "3.10.0",
-    "simple-commit-message": "2.1.1",
-    "standard": "8.0.0-beta.3"
+    "pre-git": "3.17.1",
+    "simple-commit-message": "4.0.13",
+    "standard": "14.1.0"
   },
   "dependencies": {
-    "available-versions": "0.13.2",
-    "changed-log": "0.11.0",
-    "npm-utils": "1.7.1"
+    "available-versions": "0.13.7",
+    "changed-log": "0.13.0",
+    "npm-utils": "2.0.3"
   },
   "config": {
     "pre-git": {


### PR DESCRIPTION
Installing with yarn gave several warnings[1] due to outdated dependencies. Most of these have been eliminated with a version bump. Quick scans over diffs of each package show nothing concerning.

The remaining warnings are wrt `changed-log`; whilst bumping it will be required it isn't as simple as this PR.


[1] The warnings:
```
warning ci-publish > changed-log > github@2.4.0: 'github' has been renamed to '@octokit/rest' (https://git.io/vNB11)
warning ci-publish > available-versions > request > hawk@3.1.3: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
warning ci-publish > available-versions > request > hawk > cryptiles@2.0.5: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
warning ci-publish > available-versions > request > hawk > sntp@1.0.9: This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
warning ci-publish > available-versions > request > hawk > boom@2.10.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
warning ci-publish > available-versions > request > hawk > cryptiles > boom@2.10.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
warning ci-publish > available-versions > request > hawk > hoek@2.16.3: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
warning ci-publish > available-versions > request > hawk > sntp > hoek@2.16.3: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
warning ci-publish > available-versions > request > hawk > boom > hoek@2.16.3: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
```